### PR TITLE
feat: patch svgo to remove deprecated `stable`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   ],
   "pnpm": {
     "patchedDependencies": {
-      "strict-event-emitter@0.2.4": "patches/strict-event-emitter@0.2.4.patch"
+      "strict-event-emitter@0.2.4": "patches/strict-event-emitter@0.2.4.patch",
+      "svgo@2.8.0": "patches/svgo@2.8.0.patch"
     },
     "overrides": {
       "useragent": "npm:@kingyue/useragent@^2.4.0"

--- a/patches/svgo@2.8.0.patch
+++ b/patches/svgo@2.8.0.patch
@@ -1,0 +1,89 @@
+diff --git a/lib/css-tools.js b/lib/css-tools.js
+index a59aae6e765ddaeee3eab6f8dda56b7c85245654..f14fba8c4d368f6c2025091bb32d9a26e0ce28ad 100644
+--- a/lib/css-tools.js
++++ b/lib/css-tools.js
+@@ -2,7 +2,6 @@
+ 
+ var csstree = require('css-tree'),
+   List = csstree.List,
+-  stable = require('stable'),
+   specificity = require('csso/lib/restructure/prepare/specificity');
+ 
+ /**
+@@ -162,7 +161,7 @@ function _bySelectorSpecificity(selectorA, selectorB) {
+  * @return {Array} Stable sorted selectors
+  */
+ function sortSelectors(selectors) {
+-  return stable(selectors, _bySelectorSpecificity);
++  return [...selectors].sort(_bySelectorSpecificity);
+ }
+ 
+ /**
+diff --git a/lib/style.js b/lib/style.js
+index 1873e7bd051243b97cd43462fcd50a617f282c7b..d575631beedd9cf76fb57611967c996dd3f98dbd 100644
+--- a/lib/style.js
++++ b/lib/style.js
+@@ -13,7 +13,6 @@
+  * @typedef {import('./types').XastChild} XastChild
+  */
+ 
+-const stable = require('stable');
+ const csstree = require('css-tree');
+ // @ts-ignore not defined in @types/csso
+ const specificity = require('csso/lib/restructure/prepare/specificity');
+@@ -249,9 +248,7 @@ const collectStylesheet = (root) => {
+     },
+   });
+   // sort by selectors specificity
+-  stable.inplace(rules, (a, b) =>
+-    compareSpecificity(a.specificity, b.specificity)
+-  );
++  rules.sort((a, b) => compareSpecificity(a.specificity, b.specificity));
+   return { rules, parents };
+ };
+ exports.collectStylesheet = collectStylesheet;
+diff --git a/package.json b/package.json
+index d827b03e25e1ad95234c83e6eec4a42485b7618f..a97f8a35d45034ceecb78372f92d46a348fece0c 100644
+--- a/package.json
++++ b/package.json
+@@ -105,8 +105,7 @@
+     "css-select": "^4.1.3",
+     "css-tree": "^1.1.3",
+     "csso": "^4.2.0",
+-    "picocolors": "^1.0.0",
+-    "stable": "^0.1.8"
++    "picocolors": "^1.0.0"
+   },
+   "devDependencies": {
+     "@rollup/plugin-commonjs": "^20.0.0",
+diff --git a/plugins/inlineStyles.js b/plugins/inlineStyles.js
+index a19f3fbd5a3ed808b9d54f6da904d2f01c3ea766..bdd5090e2adcac2f13bb27fa25bfd9015f67a483 100644
+--- a/plugins/inlineStyles.js
++++ b/plugins/inlineStyles.js
+@@ -9,7 +9,6 @@
+ const csstree = require('css-tree');
+ // @ts-ignore not defined in @types/csso
+ const specificity = require('csso/lib/restructure/prepare/specificity');
+-const stable = require('stable');
+ const {
+   visitSkip,
+   querySelectorAll,
+@@ -200,11 +199,13 @@ exports.fn = (root, params) => {
+           return;
+         }
+         // stable sort selectors
+-        const sortedSelectors = stable(selectors, (a, b) => {
+-          const aSpecificity = specificity(a.item.data);
+-          const bSpecificity = specificity(b.item.data);
+-          return compareSpecificity(aSpecificity, bSpecificity);
+-        }).reverse();
++        const sortedSelectors = [...selectors]
++          .sort((a, b) => {
++            const aSpecificity = specificity(a.item.data);
++            const bSpecificity = specificity(b.item.data);
++            return compareSpecificity(aSpecificity, bSpecificity);
++          })
++          .reverse();
+ 
+         for (const selector of sortedSelectors) {
+           // match selectors

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ patchedDependencies:
   strict-event-emitter@0.2.4:
     hash: x5jlk7tuhzo2bndbht7eprupya
     path: patches/strict-event-emitter@0.2.4.patch
+  svgo@2.8.0:
+    hash: 4lg5s6jdz5l4zubi6maaapuqiu
+    path: patches/svgo@2.8.0.patch
 
 specifiers:
   '@intlify/unplugin-vue-i18n': ^0.5.0
@@ -5366,7 +5369,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /svgo/2.8.0:
+  /svgo/2.8.0_4lg5s6jdz5l4zubi6maaapuqiu:
     resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -5377,8 +5380,8 @@ packages:
       css-tree: 1.1.3
       csso: 4.2.0
       picocolors: 1.0.0
-      stable: 0.1.8
     dev: true
+    patched: true
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -5866,7 +5869,7 @@ packages:
       vue-template-compiler: ^2.2.0
     dependencies:
       '@vue/component-compiler-utils': 3.3.0_lodash@4.17.21
-      svgo: 2.8.0
+      svgo: 2.8.0_4lg5s6jdz5l4zubi6maaapuqiu
       vue-template-compiler: 2.7.10
     transitivePeerDependencies:
       - arc-templates


### PR DESCRIPTION
svgo has a dependency `stable` which is deprecated and should be removed 
https://github.com/svg/svgo/pull/1681